### PR TITLE
Set up S3 bucket for validator snapshots

### DIFF
--- a/custom_projects/dos-validator-snapshots/.gitignore
+++ b/custom_projects/dos-validator-snapshots/.gitignore
@@ -1,0 +1,2 @@
+# Ignored because the main flow happens in Terraform Cloud
+.terraform.lock.hcl

--- a/custom_projects/dos-validator-snapshots/README.md
+++ b/custom_projects/dos-validator-snapshots/README.md
@@ -1,0 +1,11 @@
+# dos-validator-snapshots
+
+## Deployment
+
+Create a Terraform Cloud workspace named `dos-validator-snapshots` with VCS path pointing to this directory.
+
+Set up variables for the acting user:
+* AWS_ACCESS_KEY_ID
+* AWS_SECRET_ACCESS_KEY
+
+Deploy via Terrform Cloud.

--- a/custom_projects/dos-validator-snapshots/main.tf
+++ b/custom_projects/dos-validator-snapshots/main.tf
@@ -19,7 +19,8 @@ data "aws_iam_policy_document" "bucket_permissions" {
     principals {
       type = "AWS"
       identifiers = [
-        "075421299018" # dydxopsdao organization account
+        "075421299018", # dydxopsdao organization account
+	"637423473456" # Jerome from KingNodes
       ]
     }
 

--- a/custom_projects/dos-validator-snapshots/main.tf
+++ b/custom_projects/dos-validator-snapshots/main.tf
@@ -1,0 +1,61 @@
+resource "aws_s3_bucket" "public_snapshots" {
+  bucket = "dydx-snapshots-public"
+}
+
+# Unlock public access to the bucket
+resource "aws_s3_bucket_public_access_block" "public_access_block" {
+  bucket = aws_s3_bucket.public_snapshots.id
+
+  block_public_acls       = false
+  block_public_policy     = false
+  ignore_public_acls      = false
+  restrict_public_buckets = false
+}
+
+data "aws_iam_policy_document" "bucket_permissions" {
+
+  # Write access only for selected accounts
+  statement {
+    principals {
+      type = "AWS"
+      identifiers = [
+        "075421299018" # dydxopsdao organization account
+      ]
+    }
+
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:PutObject",
+      "s3:DeleteObject",
+    ]
+
+    resources = [
+      aws_s3_bucket.public_snapshots.arn,
+      "${aws_s3_bucket.public_snapshots.arn}/*",
+    ]
+  }
+
+  # Read access for the world
+  statement {
+    principals {
+      type = "*"
+      identifiers = ["*"]
+    }
+
+    actions = [
+      "s3:GetObject",
+      "s3:ListBucket",
+    ]
+
+    resources = [
+      aws_s3_bucket.public_snapshots.arn,
+      "${aws_s3_bucket.public_snapshots.arn}/*",
+    ]
+  }
+}
+
+resource "aws_s3_bucket_policy" "bucket_permissions" {
+  bucket = aws_s3_bucket.public_snapshots.id
+  policy = data.aws_iam_policy_document.bucket_permissions.json
+}

--- a/custom_projects/dos-validator-snapshots/output.tf
+++ b/custom_projects/dos-validator-snapshots/output.tf
@@ -1,0 +1,3 @@
+output "aws_s3_bucket_arn" {
+  value     = aws_s3_bucket.public_snapshots.arn
+}

--- a/custom_projects/dos-validator-snapshots/providers.tf
+++ b/custom_projects/dos-validator-snapshots/providers.tf
@@ -1,0 +1,25 @@
+terraform {
+  cloud {
+    organization = "dydxopsdao"
+
+    workspaces {
+      name = "dos-validator-snapshots"
+    }
+  }
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.32"
+    }
+  }
+
+  required_version = "~> 1.5"
+}
+
+provider "aws" {
+  # Expects the following environment variables:
+  # - AWS_ACCESS_KEY_ID
+  # - AWS_SECRET_ACCESS_KEY
+  region = var.region
+}

--- a/custom_projects/dos-validator-snapshots/variables.tf
+++ b/custom_projects/dos-validator-snapshots/variables.tf
@@ -1,0 +1,5 @@
+variable "region" {
+  type        = string
+  description = "AWS region for deployment."
+  default     = "ap-northeast-1"
+}


### PR DESCRIPTION
This PR sets ups an S3 bucket named `dydx-snapshots-public` that's publicly readable but writable only for the designated AWS accounts. The setup lives in the AWS member account of the Subdao organization, dubbed `dos-validator-snapshots`.