### PR TITLE
add require ebs encryption

### DIFF
--- a/aws_organization/main.tf
+++ b/aws_organization/main.tf
@@ -47,4 +47,52 @@ module "region_restriction_scp" {
   target_ids = var.region_restriction_target_ids
 }
 
+module "prevent_disable_ebs_encryption_scp" {
+  source = "./modules/aws_organization_scp"
+  providers = {
+    aws = aws.org_level
+  }
+  policy_name        = "PreventDisableEBSEncryption"
+  policy_description = "Prevents disabling default EBS encryption"
+  policy_statements = [
+    {
+      effect     = "Deny"
+      actions    = ["ec2:DisableEbsEncryptionByDefault"]
+      resources  = ["*"]
+      conditions = []
+    }
+  ]
+  target_ids = var.require_ebs_encryption_target_ids
+}
+
+module "deny_unencrypted_ebs_volumes_scp" {
+  source = "./modules/aws_organization_scp"
+  providers = {
+    aws = aws.org_level
+  }
+  policy_name        = "DenyUnencryptedEBSVolumes"
+  policy_description = "Denies creation of unencrypted EBS volumes"
+  policy_statements = [
+    {
+      effect    = "Deny"
+      actions   = ["ec2:CreateVolume"]
+      resources = ["*"]
+      conditions = [
+        {
+          test     = "Bool"
+          variable = "ec2:Encrypted"
+          values   = ["false"]
+        }
+      ]
+    }
+  ]
+  target_ids = var.require_ebs_encryption_target_ids
+}
+
+# Enable default EBS encryption for ap-northeast-1
+resource "aws_ebs_encryption_by_default" "ap_northeast_1" {
+  provider = aws.org_level
+  enabled  = true
+}
+
 # Other AWS organization-related resources and modules can be added here

--- a/aws_organization/terraform.tfvars
+++ b/aws_organization/terraform.tfvars
@@ -53,5 +53,6 @@ approved_regions = [
     "eu-west-1"
 ]
 region_restriction_target_ids = ["r-9w63"]
+require_ebs_encryption_target_ids = ["r-9w63"]
 
 # Other variables related to AWS organization management can be added here

--- a/aws_organization/variables.tf
+++ b/aws_organization/variables.tf
@@ -18,4 +18,10 @@ variable "region_restriction_target_ids" {
   description = "Target IDs for the region restriction SCP"
 }
 
+variable "require_ebs_encryption_target_ids" {
+  type        = list(string)
+  description = "Target IDs for the deny unencrypted ebs volumes and prevent disable ebs encryption SCPs"
+}
+
+
 # Other variables related to AWS organization management can be added here


### PR DESCRIPTION
- Enable default EBS encryption for ap-northeast-1 (activation is per region)
- Add SCP that denies creation of unencrypted EBS volumes
- Add SCP that prevents disabling default EBS encryption