### PR TITLE
chore: Consolidate SCP policies and add two new security SCPs

### DIFF
--- a/aws_organization/main.tf
+++ b/aws_organization/main.tf
@@ -5,23 +5,87 @@ module "password_policy_dos_organization" {
   }
 }
 
+# Enable default EBS encryption for ap-northeast-1
+resource "aws_ebs_encryption_by_default" "ap_northeast_1" {
+  provider = aws.org_level
+  enabled  = true
+}
+
 data "aws_organizations_organization" "org" {}
 
-module "prevent_leave_org_scp" {
+module "ebs_encryption_policy" {
   source = "./modules/aws_organization_scp"
   providers = {
     aws = aws.org_level
   }
-  policy_name        = "PreventLeaveOrganization"
-  policy_description = "Prevents accounts from leaving the organization"
+  policy_name        = "EnforceEBSEncryption"
+  policy_description = "Prevents disabling default EBS encryption and denies the creation of unencrypted EBS volumes."
+  
+  policy_statements = [
+    {
+      effect     = "Deny"
+      actions    = ["ec2:DisableEbsEncryptionByDefault"]
+      resources  = ["*"]
+      conditions = []
+    },
+    {
+      effect    = "Deny"
+      actions   = ["ec2:CreateVolume"]
+      resources = ["*"]
+      conditions = [
+        {
+          test     = "Bool"
+          variable = "ec2:Encrypted"
+          values   = ["false"]
+        }
+      ]
+    }
+  ]
+
+  target_ids = [data.aws_organizations_organization.org.roots[0].id]
+}
+
+module "security_controls_policy" {
+  source = "./modules/aws_organization_scp"
+  providers = {
+    aws = aws.org_level
+  }
+  policy_name        = "SecurityControls"
+  policy_description = "Combines security controls to prevent root user actions, prevent leaving the organization, and control IAM Identity center instance creation."
+
   policy_statements = [
     {
       effect     = "Deny"
       actions    = ["organizations:LeaveOrganization"]
       resources  = ["*"]
       conditions = []
+    },
+    {
+      effect    = "Deny"
+      actions   = ["*"]
+      resources  = ["*"]
+      conditions = [
+        {
+          test     = "StringLike"
+          variable = "aws:PrincipalArn"
+          values   = ["arn:aws:iam::*:root"]
+        }
+      ]
+    },
+    {
+      effect    = "Deny"
+      actions   = ["sso:CreateInstance"]
+      resources = ["*"]
+      conditions = [
+        {
+          test     = "StringNotEquals"
+          variable = "aws:PrincipalAccount"
+          values   = [data.aws_organizations_organization.org.master_account_id]
+        }
+      ]
     }
   ]
+
   target_ids = [data.aws_organizations_organization.org.roots[0].id]
 }
 
@@ -31,7 +95,8 @@ module "region_restriction_scp" {
     aws = aws.org_level
   }
   policy_name        = "RegionRestriction"
-  policy_description = "Restricts usage to approved regions"
+  policy_description = "Restricts usage to approved regions."
+  
   policy_statements = [
     {
       effect      = "Deny"
@@ -46,55 +111,8 @@ module "region_restriction_scp" {
       ]
     }
   ]
-  target_ids = [data.aws_organizations_organization.org.roots[0].id]
-}
 
-module "prevent_disable_ebs_encryption_scp" {
-  source = "./modules/aws_organization_scp"
-  providers = {
-    aws = aws.org_level
-  }
-  policy_name        = "PreventDisableEBSEncryption"
-  policy_description = "Prevents disabling default EBS encryption"
-  policy_statements = [
-    {
-      effect     = "Deny"
-      actions    = ["ec2:DisableEbsEncryptionByDefault"]
-      resources  = ["*"]
-      conditions = []
-    }
-  ]
   target_ids = [data.aws_organizations_organization.org.roots[0].id]
-}
-
-module "deny_unencrypted_ebs_volumes_scp" {
-  source = "./modules/aws_organization_scp"
-  providers = {
-    aws = aws.org_level
-  }
-  policy_name        = "DenyUnencryptedEBSVolumes"
-  policy_description = "Denies creation of unencrypted EBS volumes"
-  policy_statements = [
-    {
-      effect    = "Deny"
-      actions   = ["ec2:CreateVolume"]
-      resources = ["*"]
-      conditions = [
-        {
-          test     = "Bool"
-          variable = "ec2:Encrypted"
-          values   = ["false"]
-        }
-      ]
-    }
-  ]
-  target_ids = [data.aws_organizations_organization.org.roots[0].id]
-}
-
-# Enable default EBS encryption for ap-northeast-1
-resource "aws_ebs_encryption_by_default" "ap_northeast_1" {
-  provider = aws.org_level
-  enabled  = true
 }
 
 # Other AWS organization-related resources and modules can be added here


### PR DESCRIPTION
- consolidate distinct SCP policies into logical SCP policies with multiple policy statements to avoid "maximum number of policies attached" aws limit
- add SCP to prevent root user actions
- add SCP to only allow IAM Identity center instance creation in mgmt account